### PR TITLE
NIFI-3536

### DIFF
--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/pom.xml
@@ -117,7 +117,12 @@
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/pom.xml
@@ -28,6 +28,7 @@
     <properties>
         <axis2.version>1.7.1</axis2.version>
         <axiom.version>1.2.18</axiom.version>
+        <jackson.version>2.7.4</jackson.version>
     </properties>
     <dependencies>
         <dependency>
@@ -40,7 +41,11 @@
             <artifactId>axis2-transport-http</artifactId>
             <version>${axis2.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.axis2</groupId>
+            <artifactId>axis2-jaxws</artifactId>
+            <version>${axis2.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
@@ -75,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -100,20 +105,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.7.4</version>
-            <scope>test</scope>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.4</version>
-            <scope>test</scope>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.4</version>
-            <scope>test</scope>
+            <version>${jackson.version}</version>
         </dependency>
 
 

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/main/java/org/apache/nifi/processors/soap/GetSOAP.java
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/main/java/org/apache/nifi/processors/soap/GetSOAP.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.processors.soap;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
@@ -37,6 +39,9 @@ import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.annotation.lifecycle.OnStopped;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
@@ -46,33 +51,29 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.processor.io.OutputStreamCallback;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.util.StopWatch;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
-import static org.apache.axis2.namespace.Constants.URI_SOAP12_ENV;
-
-
 @SupportsBatching
-@InputRequirement(InputRequirement.Requirement.INPUT_FORBIDDEN)
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
 @Tags({"SOAP", "Get", "Ingest", "Ingress"})
-@CapabilityDescription("Execute provided request against the SOAP endpoint. The result will be left in it's orginal form. " +
+@CapabilityDescription(
+        "Execute provided request against the SOAP endpoint. The result will be left in it's orginal form. " +
         "This processor can be scheduled to run on a timer, or cron expression, using the standard scheduling methods, " +
         "or it can be triggered by an incoming FlowFile. If it is triggered by an incoming FlowFile, then attributes of " +
         "that FlowFile will be available when evaluating the executing the SOAP request.")
 @WritesAttribute(attribute = "mime.type", description = "Sets mime type to text/xml")
 @DynamicProperty(name = "The name of a input parameter the needs to be passed to the SOAP method being invoked.",
-        value = "The value for this parameter '=' and ',' are not considered valid values and must be escpaed . Note, if the value of parameter needs to be an array the format should be key1=value1,key2=value2.  ",
+        value = "The value for this parameter '=' and ',' are not considered valid values and must be escaped . " +
+                "Note, if the value of parameter needs to be an array the format should be key1=value1,key2=value2.  ",
         description = "The name provided will be the name sent in the SOAP method, therefore please make sure " +
-                "it matches the wsdl documentation for the SOAP service being called. In the case of arrays " +
-                "the name will be the name of the array and the key's specified in the value will be the element " +
-                "names pased.")
+                      "it matches the wsdl documentation for the SOAP service being called. In the case of arrays " +
+                      "the name will be the name of the array and the key's specified in the value will be the element " +
+                      "names pased.")
 
 public class GetSOAP extends AbstractProcessor {
-
 
     protected static final PropertyDescriptor ENDPOINT_URL = new PropertyDescriptor
             .Builder()
@@ -103,7 +104,7 @@ public class GetSOAP extends AbstractProcessor {
 
     protected static final PropertyDescriptor USER_NAME = new PropertyDescriptor
             .Builder()
-            .name("User name")
+            .name("Username")
             .sensitive(true)
             .description("The username to use in the case of basic Auth")
             .required(false)
@@ -120,7 +121,6 @@ public class GetSOAP extends AbstractProcessor {
             .expressionLanguageSupported(false)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .build();
-
 
     protected static final PropertyDescriptor USER_AGENT = new PropertyDescriptor
             .Builder()
@@ -152,20 +152,74 @@ public class GetSOAP extends AbstractProcessor {
             .addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
             .build();
 
+    protected static final PropertyDescriptor AUTH_BY_HEADER = new PropertyDescriptor.Builder()
+            .name("HeaderAuthentication")
+            .description("If you need to do authentication with SOAP headers, this must be a json string " +
+                         "defining the structure since it varies from service to service. For example, " +
+                         "{ \"UserAuthentication\": { \"username\": \"larry\", \"password\": \"abc123\"," +
+                         " \"some_other_custom_field\": \"value\" }")
+            .required(false)
+            .expressionLanguageSupported(true)
+            .sensitive(true)
+            .dynamic(false)
+            .addValidator(new Validator() {
+                @Override
+                public ValidationResult validate(String subject, String value, ValidationContext context) {
+                    try {
+                        return (new ValidationResult.Builder())
+                                .subject(subject)
+                                .input(value)
+                                .explanation("Header Authentication must be empty or valid json")
+                                .valid("".equals(value) || mapper.readTree(value) != null).build();
+                    }
+                    catch (IOException e) {
+                        return (new ValidationResult.Builder())
+                                .subject(subject)
+                                .input(value)
+                                .explanation("Header Authentication must be empty or valid json: " + e.getMessage())
+                                .valid(false).build();
+                    }
+                }
+            })
+            .build();
+
+    protected static final PropertyDescriptor API_NAMESPACE = new PropertyDescriptor.Builder()
+            .name("Namespace")
+            .description("XML Namespace.")
+            .required(true)
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .dynamic(false)
+            .build();
+
+    protected static final PropertyDescriptor SKIP_FIRST_ELEMENT = new PropertyDescriptor.Builder()
+            .name("SkipFirstElement")
+            .description("Return the XML that comes after the first element.")
+            .required(true)
+            .defaultValue("false")
+            .allowableValues("true", "false")
+            .expressionLanguageSupported(false)
+            .addValidator(StandardValidators.BOOLEAN_VALIDATOR)
+            .dynamic(false)
+            .build();
 
     public static final Relationship REL_SUCCESS = new Relationship.Builder()
             .name("success")
             .description("All FlowFiles that are created are routed to this relationship")
             .build();
 
-
     private List<PropertyDescriptor> descriptors;
 
     private ServiceClient serviceClient;
+    private OMFactory fac = OMAbstractFactory.getOMFactory();
+    private OMNamespace omNamespace;
+    private OMElement authHeader = null;
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private boolean skipFirstElement = false;
 
     @Override
     protected void init(final ProcessorInitializationContext context) {
-        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        final List<PropertyDescriptor> descriptors = new ArrayList<>();
         descriptors.add(ENDPOINT_URL);
         descriptors.add(WSDL_URL);
         descriptors.add(METHOD_NAME);
@@ -174,8 +228,10 @@ public class GetSOAP extends AbstractProcessor {
         descriptors.add(USER_AGENT);
         descriptors.add(SO_TIMEOUT);
         descriptors.add(CONNECTION_TIMEOUT);
+        descriptors.add(AUTH_BY_HEADER);
+        descriptors.add(API_NAMESPACE);
+        descriptors.add(SKIP_FIRST_ELEMENT);
         this.descriptors = Collections.unmodifiableList(descriptors);
-
     }
 
     @Override
@@ -193,8 +249,13 @@ public class GetSOAP extends AbstractProcessor {
     @Override
     protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
         return new PropertyDescriptor.Builder()
-                .description("Specifies the method name and parameter names and values for '" + propertyDescriptorName + "' the SOAP method being called.")
-                .name(propertyDescriptorName).addValidator(StandardValidators.NON_EMPTY_VALIDATOR).dynamic(true)
+                .description("Specifies the method name and parameter names and values for '" +
+                             propertyDescriptorName +
+                             "' the SOAP method being called.")
+                .name(propertyDescriptorName)
+                .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+                .dynamic(true)
+                .expressionLanguageSupported(true)
                 .build();
     }
 
@@ -214,38 +275,85 @@ public class GetSOAP extends AbstractProcessor {
         options.setCallTransportCleanup(true);
         options.setProperty(HTTPConstants.CHUNKED, false);
 
-
         options.setProperty(HTTPConstants.USER_AGENT, context.getProperty(USER_AGENT).getValue());
         options.setProperty(HTTPConstants.SO_TIMEOUT, context.getProperty(SO_TIMEOUT).asInteger());
         options.setProperty(HTTPConstants.CONNECTION_TIMEOUT, context.getProperty(CONNECTION_TIMEOUT).asInteger());
-        options.setSoapVersionURI(URI_SOAP12_ENV);
-        //get the username and password -- they both must be populated.
+        //get the username and password -- they both must be populated if using basic auth.
 
         final String userName = context.getProperty(USER_NAME).getValue();
         final String password = context.getProperty(PASSWORD).getValue();
-        if (null != userName && null != password && !userName.isEmpty() && !password.isEmpty()) {
+        final String apiNamespace = context.getProperty(API_NAMESPACE).getValue();
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("Username", userName);
+        attributes.put("Password", password);
+        // Evaluate the contents of authByHeader and allow variable replacement with $Username $Password
+        final String authByHeader = context.getProperty(AUTH_BY_HEADER)
+                                           .evaluateAttributeExpressions(attributes)
+                                           .getValue();
+        skipFirstElement = context.getProperty(SKIP_FIRST_ELEMENT).asBoolean();
 
+        omNamespace = fac.createOMNamespace(apiNamespace, "ns1");
+        if (authByHeader != null && !"".equals(authByHeader)) {
+            Map<String, Object> map = null;
+            try {
+                map = mapper.readValue(authByHeader,
+                                       new TypeReference<Map<String, Object>>() {
+                                       });
+            }
+            catch (IOException e) {
+                getLogger().error(e.getMessage(), e);
+            }
+
+            authHeader = createAuthHeader(null, map);
+        } else if (null != userName && null != password && !userName.isEmpty() && !password.isEmpty()) {
             HttpTransportPropertiesImpl.Authenticator
                     auth = new HttpTransportPropertiesImpl.Authenticator();
             auth.setUsername(userName);
             auth.setPassword(password);
             options.setProperty(org.apache.axis2.transport.http.HTTPConstants.AUTHENTICATE, auth);
         }
+
         try {
             serviceClient = new ServiceClient();
+            // TODO: Not sure if this will apply in all cases. Some services require SOAPAction, some don't.
+            options.setAction(apiNamespace + context.getProperty(METHOD_NAME).getValue());
             serviceClient.setOptions(options);
-        } catch (AxisFault axisFault) {
-            getLogger().error("Failed to create webservice client, please check that the service endpoint is available and " +
-                    "the property is valid.", axisFault);
+        }
+        catch (AxisFault axisFault) {
+            getLogger().error(
+                    "Failed to create webservice client, please check that the service endpoint is available and " +
+                    "the property is valid.",
+                    axisFault);
             throw new ProcessException(axisFault);
         }
+    }
+
+    protected OMElement createAuthHeader(OMElement parent, Map<String, Object> map) {
+        OMElement element = null;
+        if (map != null) {
+            for (String key : map.keySet()) {
+                element = fac.createOMElement(key, omNamespace);
+                Object value = map.get(key);
+                if (value instanceof String) {
+                    element.setText(value.toString());
+                    if (parent != null) {
+                        parent.addChild(element);
+                    }
+                } else {
+                    OMElement childElement = createAuthHeader(element, (Map) value);
+                    element.addChild(childElement);
+                }
+            }
+        }
+        return element;
     }
 
     @OnStopped
     public void onStopped(final ProcessContext context) {
         try {
             serviceClient.cleanup();
-        } catch (AxisFault axisFault) {
+        }
+        catch (AxisFault axisFault) {
             getLogger().error("Failed to clean up the web service client.", axisFault);
             throw new ProcessException(axisFault);
         }
@@ -253,67 +361,86 @@ public class GetSOAP extends AbstractProcessor {
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        FlowFile flowFile = session.get();
+        if (flowFile == null) {
+            return;
+        }
 
-        final StopWatch stopWatch = new StopWatch(true);
         //get the dynamic properties, execute the call and return the results
-        OMFactory fac = OMAbstractFactory.getOMFactory();
-        OMNamespace omNamespace = fac.createOMNamespace(context.getProperty(WSDL_URL).getValue(), "nifi");
-
         final OMElement method = getSoapMethod(fac, omNamespace, context.getProperty(METHOD_NAME).getValue());
 
         //now we need to walk the arguments and add them
-        addArgumentsToMethod(context, fac, omNamespace, method);
+        addArgumentsToMethod(context, fac, omNamespace, method, flowFile);
         final OMElement result = executeSoapMethod(method);
-        final FlowFile flowFile = processSoapRequest(session, result);
+        getLogger().debug("RESULT" + result);
+        flowFile = processSoapRequest(session, result, flowFile);
+
+        // TODO: should add a failure situation?
         session.transfer(flowFile, REL_SUCCESS);
 
     }
 
-    FlowFile processSoapRequest(ProcessSession session, final OMElement result) {
-
-        FlowFile intermediateFlowFile = session.create();
-
-        intermediateFlowFile = session.write(intermediateFlowFile, new OutputStreamCallback() {
-            @Override
-            public void process(final OutputStream out) throws IOException {
-                try {
+    FlowFile processSoapRequest(ProcessSession session, final OMElement result, FlowFile flowFile) {
+        flowFile = session.write(flowFile, out -> {
+            try {
+                if (skipFirstElement) {
                     String response = result.getFirstElement().getText();
                     out.write(response.getBytes());
-                } catch (AxisFault axisFault) {
-                    final ComponentLog logger = getLogger();
-                    if (null != logger)
-                        logger.error("Failed parsing the data that came back from the web service method", axisFault);
-                    throw new ProcessException(axisFault);
+                } else {
+                    out.write(result.toString().getBytes());
                 }
+            }
+            catch (AxisFault axisFault) {
+                final ComponentLog logger = getLogger();
+                if (null != logger) {
+                    logger.error("Failed parsing the data that came back from the web service method", axisFault);
+                }
+                throw new ProcessException(axisFault);
             }
         });
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.MIME_TYPE.key(), "application/xml");
-        return session.putAllAttributes(intermediateFlowFile, attributes);
+        return session.putAllAttributes(flowFile, attributes);
     }
 
     OMElement executeSoapMethod(OMElement method) {
         try {
+            if (authHeader != null) {
+                serviceClient.addHeader(authHeader);
+            }
+            getLogger().info("Sending authHeader: " + authHeader);
+            getLogger().info("Sending method: " + method);
             return serviceClient.sendReceive(method);
-        } catch (AxisFault axisFault) {
+        }
+        catch (AxisFault axisFault) {
             final ComponentLog logger = getLogger();
-            if (null != logger)
+            if (null != logger) {
                 logger.error("Failed invoking the web service method", axisFault);
+            }
             throw new ProcessException(axisFault);
         }
     }
 
-    void addArgumentsToMethod(ProcessContext context, OMFactory fac, OMNamespace omNamespace, OMElement method) {
+    void addArgumentsToMethod(ProcessContext context,
+                              OMFactory fac,
+                              OMNamespace omNamespace,
+                              OMElement method,
+                              FlowFile flowFile) {
         final ComponentLog logger = getLogger();
         for (final Map.Entry<PropertyDescriptor, String> entry : context.getProperties().entrySet()) {
             PropertyDescriptor descriptor = entry.getKey();
             if (descriptor.isDynamic()) {
-                if (null != logger)
-                    logger.debug("Processing dynamic property: " + descriptor.getName() + " with value: " + entry.getValue());
+                if (null != logger) {
+                    logger.debug("Processing dynamic property: " +
+                                 descriptor.getName() +
+                                 " with value: " +
+                                 entry.getValue());
+                }
                 OMElement value = getSoapMethod(fac, omNamespace, descriptor.getName());
-
-                value.addChild(fac.createOMText(value, entry.getValue()));
+                // Allow for expression language in dynamic parameters
+                String v = context.getProperty(descriptor).evaluateAttributeExpressions(flowFile).getValue();
+                value.addChild(fac.createOMText(value, v));
                 method.addChild(value);
             }
         }

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/main/java/org/apache/nifi/processors/soap/GetSOAP.java
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/main/java/org/apache/nifi/processors/soap/GetSOAP.java
@@ -155,13 +155,13 @@ public class GetSOAP extends AbstractProcessor {
     protected static final PropertyDescriptor AUTH_BY_HEADER = new PropertyDescriptor.Builder()
             .name("HeaderAuthentication")
             .description("If you need to do authentication with SOAP headers, this must be a json string " +
-                         "defining the structure since it varies from service to service. For example, " +
-                         "{ \"UserAuthentication\": { \"username\": \"larry\", \"password\": \"abc123\"," +
+                         "defining the structure since it varies from service to service. Username and Password " +
+                         "must be set in the separate parameters to this processors and referenced here " +
+                         "as variables ${Username} and ${Password}. For example, " +
+                         "{ \"UserAuthentication\": { \"username\": \"${Username}\", \"password\": \"${Password}\"," +
                          " \"some_other_custom_field\": \"value\" }")
             .required(false)
             .expressionLanguageSupported(true)
-            .sensitive(true)
-            .dynamic(false)
             .addValidator(new Validator() {
                 @Override
                 public ValidationResult validate(String subject, String value, ValidationContext context) {

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/GetSOAPIT.java
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/GetSOAPIT.java
@@ -1,0 +1,145 @@
+package org.apache.nifi.processors.soap;
+
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.nifi.processors.soap.GetSOAP.REL_SUCCESS;
+
+/**
+ * Integration test that will query live soap services.
+ * Created by frankm on 2/28/17.
+ */
+public class GetSOAPIT {
+
+    private static final Logger logger = LoggerFactory.getLogger(GetSOAPIT.class);
+
+    private TestRunner testRunner;
+
+    @Before
+    public void init() {
+        testRunner = TestRunners.newTestRunner(GetSOAP.class);
+    }
+
+    @After
+    public void after() {
+        testRunner.shutdown();
+    }
+
+    /**
+     * Public service that does not require authentication.
+     */
+    @Test
+    public void testWeather() {
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL,
+                               "https://graphical.weather.gov:443/xml/SOAP_server/ndfdXMLserver.php");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "LatLonListZipCode");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl");
+        testRunner.setProperty(GetSOAP.SKIP_FIRST_ELEMENT, "true");
+        testRunner.setProperty("zipCodeList", "90720");
+
+        testRunner.enqueue("");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
+        assert (null != flowFileList);
+        for (MockFlowFile flowFile : flowFileList) {
+            String data = new String(testRunner.getContentAsByteArray(flowFile));
+            logger.info("Data returned: {}", data);
+        }
+    }
+
+    /**
+     * Public service that does not require authentication. This service required the SOAPAction header to be set.
+     * The others didn't seem to require it.
+     */
+    @Test
+    public void testDilbert() {
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://gcomputer.net/webservices/dilbert.asmx");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://www.gcomputer.net/webservices/dilbert.asmx?WSDL");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "DailyDilbert");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://gcomputer.net/webservices/");
+        testRunner.setProperty("ADate", "2017-02-01T00:00:00");
+        testRunner.enqueue("");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
+        assert (null != flowFileList);
+        for (MockFlowFile flowFile : flowFileList) {
+            String data = new String(testRunner.getContentAsByteArray(flowFile));
+            logger.info("Data returned: {}", data);
+        }
+    }
+
+    /**
+     * Public service that does not require authentication.
+     */
+    @Test
+    public void testStockQuote() {
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://www.webservicex.com/stockquote.asmx");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://www.webservicex.com/stockquote.asmx?WSDL");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "GetQuote");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://www.webserviceX.NET/");
+        testRunner.setProperty(GetSOAP.SKIP_FIRST_ELEMENT, "true");
+        testRunner.setProperty("symbol", "YHOO"); // Maybe delisted soon? lol
+
+        testRunner.enqueue("");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
+        assert (null != flowFileList);
+        for (MockFlowFile flowFile : flowFileList) {
+            String data = new String(testRunner.getContentAsByteArray(flowFile));
+            logger.info("Data returned: {}", data);
+        }
+    }
+
+    /**
+     * This is a test of a private service that does require authentication. In order to run this test,
+     * you will need to fill in the endpoint, wsdl, username, password, etc.
+     */
+    @Test
+    public void testServiceWithAuthentication() {
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://api.someservice.com/v3/SomeService");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://api.someservice.com/v3/SomeService?wsdl");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "getTransactionList");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://api.someservice.com/");
+        // Testing auth by header and passing username/password as variables.
+        testRunner.setProperty(GetSOAP.AUTH_BY_HEADER, "{\"UserAuthentication\": { " +
+                                                       " \"iId\": \"${Username}\", " +
+                                                       " \"sPassword\": \"${Password}\", " +
+                                                       " \"sType\": \"merchant\" " +
+                                                       "  }" +
+                                                       "}");
+        // Username/Password must be set if referenced above
+        testRunner.setProperty(GetSOAP.USER_NAME, "PUT_YOUR_USER_NAME_HERE");
+        testRunner.setProperty(GetSOAP.PASSWORD, "PUT_YOUR_PASSWORD_HERE");
+        testRunner.setProperty("sDateType", "transaction");
+        // Make sure that dynamic properties can evaluate expression language
+        testRunner.setProperty("dStartDate", "${now():toNumber():minus(86400000):format(\"yyyy-MM-dd'T'HH:mm:ss\")}");
+        testRunner.setProperty("dEndDate", "${now():format(\"yyyy-MM-dd'T'HH:mm:ss\")}");
+
+        testRunner.enqueue("");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(GetSOAP.REL_SUCCESS);
+        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(GetSOAP.REL_SUCCESS);
+        Assert.assertNotNull(flowFileList);
+        for (MockFlowFile flowFile : flowFileList) {
+            String data = new String(testRunner.getContentAsByteArray(flowFile));
+            logger.info("DATA" + data);
+        }
+    }
+}

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/GetSOAPIT.java
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/GetSOAPIT.java
@@ -102,7 +102,8 @@ public class GetSOAPIT {
         assert (null != flowFileList);
         for (MockFlowFile flowFile : flowFileList) {
             String data = new String(testRunner.getContentAsByteArray(flowFile));
-            logger.info("Data returned: {}", data);
+            logger.debug("Data returned: {}", data);
+            Assert.assertTrue(data.startsWith("<StockQuotes><Stock><Symbol>YHOO</Symbol>"));
         }
     }
 

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/GetSOAPTest.java
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/GetSOAPTest.java
@@ -23,313 +23,211 @@ import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.om.impl.common.OMNamespaceImpl;
 import org.apache.axiom.om.impl.llom.OMElementImpl;
 import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.Relationship;
-import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
-import org.mockserver.junit.MockServerRule;
-import org.mockserver.model.Cookie;
-import org.mockserver.model.Delay;
-import org.mockserver.model.Header;
-import org.mockserver.model.Parameter;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.nifi.processors.soap.GetSOAP.REL_SUCCESS;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
-import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.model.StringBody.exact;
-import static org.mockito.Mockito.*;
 
 public class GetSOAPTest {
 
     private TestRunner testRunner;
-//    @Rule
-//    public MockServerRule mockServerRule = new MockServerRule(1080,this);
 
     private static ClientAndServer mockServer;
-   // private MockServerClient mockServerClient;
-
-    private static String wsdl = "<?xml version=\"1.0\"?>\n" +
-            "<definitions name=\"TestService\"\n" +
-            "             targetNamespace=\"http://localhost.com/stockquote.wsdl\"\n" +
-            "             xmlns:tns=\"http://localhost.com/stockquote.wsdl\"\n" +
-            "             xmlns:xsd1=\"http://localhost.com/stockquote.xsd\"\n" +
-            "             xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n" +
-            "             xmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n" +
-            "\n" +
-            "  <types>\n" +
-            "    <schema targetNamespace=\"http://localhost.com/stockquote.xsd\"\n" +
-            "            xmlns=\"http://www.w3.org/2000/10/XMLSchema\">\n" +
-            "      <element name=\"TradePriceRequest\">\n" +
-            "        <complexType>\n" +
-            "          <all>\n" +
-            "            <element name=\"tickerSymbol\" type=\"string\"/>\n" +
-            "          </all>\n" +
-            "        </complexType>\n" +
-            "      </element>\n" +
-            "      <element name=\"TradePrice\">\n" +
-            "         <complexType>\n" +
-            "           <all>\n" +
-            "             <element name=\"price\" type=\"float\"/>\n" +
-            "           </all>\n" +
-            "         </complexType>\n" +
-            "      </element>\n" +
-            "    </schema>\n" +
-            "  </types>\n" +
-            "\n" +
-            "  <message name=\"GetLastTradePriceInput\">\n" +
-            "    <part name=\"body\" element=\"xsd1:TradePriceRequest\"/>\n" +
-            "  </message>\n" +
-            "\n" +
-            "  <message name=\"GetLastTradePriceOutput\">\n" +
-            "    <part name=\"body\" element=\"xsd1:TradePrice\"/>\n" +
-            "  </message>\n" +
-            "\n" +
-            "  <portType name=\"StockQuotePortType\">\n" +
-            "    <operation name=\"GetLastTradePrice\">\n" +
-            "      <input message=\"tns:GetLastTradePriceInput\"/>\n" +
-            "      <output message=\"tns:GetLastTradePriceOutput\"/>\n" +
-            "    </operation>\n" +
-            "  </portType>\n" +
-            "\n" +
-            "  <binding name=\"StockQuoteSoapBinding\" type=\"tns:StockQuotePortType\">\n" +
-            "    <soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"/>\n" +
-            "    <operation name=\"GetLastTradePrice\">\n" +
-            "      <soap:operation soapAction=\"http://localhost.com/GetLastTradePrice\"/>\n" +
-            "      <input>\n" +
-            "        <soap:body use=\"literal\"/>\n" +
-            "      </input>\n" +
-            "      <output>\n" +
-            "        <soap:body use=\"literal\"/>\n" +
-            "      </output>\n" +
-            "    </operation>\n" +
-            "  </binding>\n" +
-            "\n" +
-            "  <service name=\"StockQuoteService\">\n" +
-            "    <documentation>My first service</documentation>\n" +
-            "    <port name=\"StockQuotePort\" binding=\"tns:StockQuoteSoapBinding\">\n" +
-            "      <soap:address location=\"http://localhost.com/stockquote\"/>\n" +
-            "    </port>\n" +
-            "  </service>\n" +
-            "\n" +
-            "</definitions>";
 
     @BeforeClass
     public static void setup() {
         mockServer = startClientAndServer(1080);
-
-       // mockServerClient = new MockServerClient("127.0.0.1", 1080);
-
     }
+
     @AfterClass
-    public static void tearDown(){
+    public static void tearDown() {
         mockServer.stop();
     }
 
     @Before
-    public  void init() {
+    public void init() {
         testRunner = TestRunners.newTestRunner(GetSOAP.class);
-
-        // mockServerClient = new MockServerClient("127.0.0.1", 1080);
     }
+
     @After
-    public void after(){
+    public void after() {
         testRunner.shutdown();
+    }
+
+    /**
+     * Verify that invalid json for the auth header throws an AssertionError
+     */
+    @Test(expected = AssertionError.class)
+    public void testInvalidHeader() {
+
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://localhost:1080/test_path");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://localhost:1080/test_path.wsdl");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "testMethod");
+        testRunner.setProperty(GetSOAP.AUTH_BY_HEADER, "{ invalid_json: \"\"");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://localhost:1080/");
+
+        testRunner.enqueue("");
+        testRunner.run();
+    }
+
+    @Test
+    public void testValidHeaderAuth() {
+        final String xmlBody = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
+                               "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
+                               "    <SOAP-ENV:Body>\n" +
+                               "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
+                               "            <listLatLonOut xsi:type=\"xsd:string\"></listLatLonOut>\n" +
+                               "        </ns1:LatLonListZipCodeResponse>\n" +
+                               "    </SOAP-ENV:Body>\n" +
+                               "</SOAP-ENV:Envelope>";
+
+        new MockServerClient("127.0.0.1", 1080).when(request().withMethod("POST"))
+                                               .respond(response().withBody(xmlBody));
+
+        testRunner.setProperty(GetSOAP.AUTH_BY_HEADER, "{\n" +
+                                                       "  \"UserAuthentication\": {\n" +
+                                                       "    \"iId\": \"myuser\",\n" +
+                                                       "    \"sPassword\": \"somepassword\",\n" +
+                                                       "    \"sType\": \"merchant\"\n" +
+                                                       "  }\n" +
+                                                       "}");
+
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://localhost:1080/test_path");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://localhost:1080/test_path.wsdl");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "testMethod");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://localhost:1080/");
+
+        testRunner.enqueue("");
+        testRunner.run();
+
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
+        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
+        assert (null != flowFileList);
     }
 
     @Test
     public void testHTTPUsernamePasswordProcessor() throws IOException {
 
-
-
         final String xmlBody = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
-                "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
-                "    <SOAP-ENV:Body>\n" +
-                "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
-                "            <listLatLonOut xsi:type=\"xsd:string\">&lt;?xml version=&apos;1.0&apos;?&gt;&lt;dwml version=&apos;1.0&apos; xmlns:xsd=&apos;http://www.w3.org/2001/XMLSchema&apos; xmlns:xsi=&apos;http://www.w3.org/2001/XMLSchema-instance&apos; xsi:noNamespaceSchemaLocation=&apos;http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd&apos;&gt;&lt;latLonList&gt;35.9153,-79.0838&lt;/latLonList&gt;&lt;/dwml&gt;</listLatLonOut>\n" +
-                "        </ns1:LatLonListZipCodeResponse>\n" +
-                "    </SOAP-ENV:Body>\n" +
-                "</SOAP-ENV:Envelope>";
+                               "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
+                               "    <SOAP-ENV:Body>\n" +
+                               "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
+                               "            <listLatLonOut xsi:type=\"xsd:string\">&lt;?xml version=&apos;1.0&apos;?&gt;&lt;dwml version=&apos;1.0&apos; xmlns:xsd=&apos;http://www.w3.org/2001/XMLSchema&apos; xmlns:xsi=&apos;http://www.w3.org/2001/XMLSchema-instance&apos; xsi:noNamespaceSchemaLocation=&apos;http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd&apos;&gt;&lt;latLonList&gt;35.9153,-79.0838&lt;/latLonList&gt;&lt;/dwml&gt;</listLatLonOut>\n" +
+                               "        </ns1:LatLonListZipCodeResponse>\n" +
+                               "    </SOAP-ENV:Body>\n" +
+                               "</SOAP-ENV:Envelope>";
 
-        new MockServerClient("127.0.0.1", 1080).when(request()
-                        .withMethod("POST")
-        )
-                .respond(
-                        response()
-                                .withBody(xmlBody)
-                );
+        new MockServerClient("127.0.0.1", 1080).when(request().withMethod("POST"))
+                                               .respond(response().withBody(xmlBody));
 
-        testRunner.setProperty(GetSOAP.ENDPOINT_URL,"http://localhost:1080/test_path");
-        testRunner.setProperty(GetSOAP.WSDL_URL,"http://localhost:1080/test_path.wsdl");
-        testRunner.setProperty(GetSOAP.METHOD_NAME,"testMethod");
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://localhost:1080/test_path");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://localhost:1080/test_path.wsdl");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "testMethod");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://localhost:1080/");
+        testRunner.setProperty(GetSOAP.SKIP_FIRST_ELEMENT, "true");
 
-
+        testRunner.enqueue("");
         testRunner.run();
 
-        final Relationship REL_SUCCESS = new Relationship.Builder()
-                .name("success")
-                .description("All FlowFiles that are created are routed to this relationship")
-                .build();
-        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS,1);
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
         List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
-        assert(null != flowFileList);
+        assert (null != flowFileList);
 
         final String expectedBody = "<?xml version='1.0'?><dwml version='1.0' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd'><latLonList>35.9153,-79.0838</latLonList></dwml>";
         flowFileList.get(0).assertContentEquals(expectedBody.getBytes());
-
 
     }
 
     @Test
     public void testHTTPWithUsernamePasswordProcessor() throws IOException {
 
-
         final String xmlBody = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
-                "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
-                "    <SOAP-ENV:Body>\n" +
-                "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
-                "            <listLatLonOut xsi:type=\"xsd:string\">&lt;?xml version=&apos;1.0&apos;?&gt;&lt;dwml version=&apos;1.0&apos; xmlns:xsd=&apos;http://www.w3.org/2001/XMLSchema&apos; xmlns:xsi=&apos;http://www.w3.org/2001/XMLSchema-instance&apos; xsi:noNamespaceSchemaLocation=&apos;http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd&apos;&gt;&lt;latLonList&gt;35.9153,-79.0838&lt;/latLonList&gt;&lt;/dwml&gt;</listLatLonOut>\n" +
-                "        </ns1:LatLonListZipCodeResponse>\n" +
-                "    </SOAP-ENV:Body>\n" +
-                "</SOAP-ENV:Envelope>";
+                               "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
+                               "    <SOAP-ENV:Body>\n" +
+                               "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
+                               "            <listLatLonOut xsi:type=\"xsd:string\">&lt;?xml version=&apos;1.0&apos;?&gt;&lt;dwml version=&apos;1.0&apos; xmlns:xsd=&apos;http://www.w3.org/2001/XMLSchema&apos; xmlns:xsi=&apos;http://www.w3.org/2001/XMLSchema-instance&apos; xsi:noNamespaceSchemaLocation=&apos;http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd&apos;&gt;&lt;latLonList&gt;35.9153,-79.0838&lt;/latLonList&gt;&lt;/dwml&gt;</listLatLonOut>\n" +
+                               "        </ns1:LatLonListZipCodeResponse>\n" +
+                               "    </SOAP-ENV:Body>\n" +
+                               "</SOAP-ENV:Envelope>";
 
-        new MockServerClient("127.0.0.1", 1080).when(request()
-                .withMethod("POST")
-        )
-                .respond(
-                        response()
-                                .withBody(xmlBody)
-                );
+        new MockServerClient("127.0.0.1", 1080).when(request().withMethod("POST"))
+                                               .respond(response().withBody(xmlBody));
 
-        testRunner.setProperty(GetSOAP.ENDPOINT_URL,"http://localhost:1080/test_path");
-        testRunner.setProperty(GetSOAP.WSDL_URL,"http://localhost:1080/test_path.wsdl");
-        testRunner.setProperty(GetSOAP.METHOD_NAME,"testMethod");
-        testRunner.setProperty(GetSOAP.USER_NAME,"username");
-        testRunner.setProperty(GetSOAP.PASSWORD,"password");
+        testRunner.setProperty(GetSOAP.ENDPOINT_URL, "http://localhost:1080/test_path");
+        testRunner.setProperty(GetSOAP.WSDL_URL, "http://localhost:1080/test_path.wsdl");
+        testRunner.setProperty(GetSOAP.METHOD_NAME, "testMethod");
+        testRunner.setProperty(GetSOAP.USER_NAME, "username");
+        testRunner.setProperty(GetSOAP.PASSWORD, "password");
+        testRunner.setProperty(GetSOAP.API_NAMESPACE, "http://localhost:1080/");
+        testRunner.setProperty(GetSOAP.SKIP_FIRST_ELEMENT, "true");
 
-
+        testRunner.enqueue("");
         testRunner.run();
 
-        final Relationship REL_SUCCESS = new Relationship.Builder()
-                .name("success")
-                .description("All FlowFiles that are created are routed to this relationship")
-                .build();
-        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS,1);
+        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS, 1);
         List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
-        assert(null != flowFileList);
+        assert (null != flowFileList);
 
         final String expectedBody = "<?xml version='1.0'?><dwml version='1.0' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd'><latLonList>35.9153,-79.0838</latLonList></dwml>";
         flowFileList.get(0).assertContentEquals(expectedBody.getBytes());
 
-
     }
 
     @Test
-    @Ignore
-    public void testGeoServiceHTTPWithArgumentsProcessor() throws IOException {
-
-
-        testRunner.setProperty(GetSOAP.ENDPOINT_URL,"http://graphical.weather.gov/xml/SOAP_server/ndfdXMLserver.php");
-        testRunner.setProperty(GetSOAP.WSDL_URL,"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl");
-        testRunner.setProperty(GetSOAP.METHOD_NAME,"LatLonListZipCode");
-        testRunner.setProperty("zipCodeList","27510");
-        testRunner.run();
-
-        final Relationship REL_SUCCESS = new Relationship.Builder()
-                .name("success")
-                .description("All FlowFiles that are created are routed to this relationship")
-                .build();
-        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS,1);
-        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
-        assert(null != flowFileList);
-
-        final String expectedBody = "<?xml version='1.0'?><dwml version='1.0' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd'><latLonList>35.9153,-79.0838</latLonList></dwml>";
-        flowFileList.get(0).assertContentEquals(expectedBody.getBytes());
-
-
-    }
-    @Test
-    @Ignore
-    public void testGetCitiesByCountry() throws IOException {
-
-
-        testRunner.setProperty(GetSOAP.ENDPOINT_URL,"http://www.webservicex.net/globalweather.asmx");
-        testRunner.setProperty(GetSOAP.WSDL_URL,"http://www.webservicex.net/globalweather.asmx?wsdl");
-        testRunner.setProperty(GetSOAP.METHOD_NAME,"GetCitiesByCountry");
-        testRunner.setProperty("CountryName","CA");
-        testRunner.run();
-
-        final Relationship REL_SUCCESS = new Relationship.Builder()
-                .name("success")
-                .description("All FlowFiles that are created are routed to this relationship")
-                .build();
-        testRunner.assertAllFlowFilesTransferred(REL_SUCCESS,1);
-        List<MockFlowFile> flowFileList = testRunner.getFlowFilesForRelationship(REL_SUCCESS);
-        assert(null != flowFileList);
-
-        final String expectedBody = "<?xml version='1.0'?><dwml version='1.0' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd'><latLonList>35.9153,-79.0838</latLonList></dwml>";
-        flowFileList.get(0).assertContentEquals(expectedBody.getBytes());
-
-
-    }
-    @Test
-    public void testRelationships(){
+    public void testRelationships() {
         GetSOAP getSOAP = new GetSOAP();
         Set<Relationship> relationshipSet = getSOAP.getRelationships();
-        assert(null != relationshipSet);
-        assert(1 == relationshipSet.size());
-
-        final Relationship REL_SUCCESS = new Relationship.Builder()
-                .name("success")
-                .description("All FlowFiles that are created are routed to this relationship")
-                .build();
-
-        assert(0 == relationshipSet.iterator().next().compareTo(REL_SUCCESS));
+        assert (null != relationshipSet);
+        assert (1 == relationshipSet.size());
+        assert (0 == relationshipSet.iterator().next().compareTo(REL_SUCCESS));
     }
-    @Test
-    public void testGetSoapMethod(){
 
+    @Test
+    public void testGetSoapMethod() {
         final String namespaceUrl = "http://localhost.com/stockquote.wsdl";
         final String namespacePrefix = "nifi";
         final String localName = "testMethod";
         OMElement expectedElement = new OMElementImpl();
-        expectedElement.setNamespace(new OMNamespaceImpl(namespaceUrl,namespacePrefix));
+        expectedElement.setNamespace(new OMNamespaceImpl(namespaceUrl, namespacePrefix));
         expectedElement.setLocalName(localName);
 
         OMFactory fac = OMAbstractFactory.getOMFactory();
-        OMNamespace omNamespace = fac.createOMNamespace(namespaceUrl,namespacePrefix);
+        OMNamespace omNamespace = fac.createOMNamespace(namespaceUrl, namespacePrefix);
 
         GetSOAP getSOAP = new GetSOAP();
-        OMElement element = getSOAP.getSoapMethod(fac,omNamespace,"testMethod");
-        assert(null != element);
-        assert(namespaceUrl.contentEquals(element.getNamespaceURI()));
-        assert(localName.contentEquals(element.getLocalName()));
-
+        OMElement element = getSOAP.getSoapMethod(fac, omNamespace, "testMethod");
+        assert (null != element);
+        assert (namespaceUrl.contentEquals(element.getNamespaceURI()));
+        assert (localName.contentEquals(element.getLocalName()));
     }
 
     @Test
-    public void testAddArguments(){
-        //addArgumentsToMethod(ProcessContext context, OMFactory fac, OMNamespace omNamespace, OMElement method)
+    public void testAddArguments() {
         final String namespaceUrl = "http://localhost.com/stockquote.wsdl";
         final String namespacePrefix = "nifi";
         final String localName = "testMethod";
         OMFactory fac = OMAbstractFactory.getOMFactory();
-        OMNamespace omNamespace = fac.createOMNamespace(namespaceUrl,namespacePrefix);
+        OMNamespace omNamespace = fac.createOMNamespace(namespaceUrl, namespacePrefix);
         OMElement expectedElement = new OMElementImpl();
-        expectedElement.setNamespace(new OMNamespaceImpl(namespaceUrl,namespacePrefix));
+        expectedElement.setNamespace(new OMNamespaceImpl(namespaceUrl, namespacePrefix));
         expectedElement.setLocalName(localName);
-
 
         PropertyDescriptor arg1 = new PropertyDescriptor
                 .Builder()
@@ -340,44 +238,18 @@ public class GetSOAPTest {
                 .expressionLanguageSupported(false)
                 .build();
 
-        testRunner.setProperty(arg1,"111");
+        testRunner.setProperty(arg1, "111");
 
         GetSOAP getSOAP = new GetSOAP();
-        getSOAP.addArgumentsToMethod(testRunner.getProcessContext(),fac,omNamespace,expectedElement);
+        getSOAP.addArgumentsToMethod(testRunner.getProcessContext(),
+                                     fac,
+                                     omNamespace,
+                                     expectedElement,
+                                     new MockFlowFile(1));
         Iterator<OMElement> childItr = expectedElement.getChildElements();
-        assert(null != childItr);
-        assert(childItr.hasNext());
-        assert(arg1.getName().contentEquals(childItr.next().getLocalName()));
-        assert(!childItr.hasNext());
-
+        assert (null != childItr);
+        assert (childItr.hasNext());
+        assert (arg1.getName().contentEquals(childItr.next().getLocalName()));
+        assert (!childItr.hasNext());
     }
-
-    @Test
-    public void testProcessResult() throws IOException {
-        final String xmlBody = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
-                "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
-                "    <SOAP-ENV:Body>\n" +
-                "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
-                "            <listLatLonOut xsi:type=\"xsd:string\">&lt;?xml version=&apos;1.0&apos;?&gt;&lt;dwml version=&apos;1.0&apos; xmlns:xsd=&apos;http://www.w3.org/2001/XMLSchema&apos; xmlns:xsi=&apos;http://www.w3.org/2001/XMLSchema-instance&apos; xsi:noNamespaceSchemaLocation=&apos;http://graphical.weather.gov/xml/DWMLgen/schema/DWML.xsd&apos;&gt;&lt;latLonList&gt;35.9153,-79.0838&lt;/latLonList&gt;&lt;/dwml&gt;</listLatLonOut>\n" +
-                "        </ns1:LatLonListZipCodeResponse>\n" +
-                "    </SOAP-ENV:Body>\n" +
-                "</SOAP-ENV:Envelope>";
-
-        final String namespaceUrl = "http://localhost.com/stockquote.wsdl";
-        final String namespacePrefix = "nifi";
-        final String localName = "testMethod";
-        OMElement expectedElement = new OMElementImpl();
-        expectedElement.setNamespace(new OMNamespaceImpl(namespaceUrl,namespacePrefix));
-        expectedElement.setLocalName(localName);
-        OMElementImpl childElement = new OMElementImpl();
-        childElement.setText(xmlBody);
-        expectedElement.addChild(childElement);
-
-        GetSOAP getSOAP = new GetSOAP();
-        FlowFile flowFile = getSOAP.processSoapRequest(testRunner.getProcessSessionFactory().createSession(),expectedElement);
-        assert(null != flowFile);
-        ((MockFlowFile)flowFile).assertContentEquals(xmlBody.getBytes());
-
-    }
-
 }

--- a/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/VerifyRequestCallback.java
+++ b/nifi-nar-bundles/nifi-soap-bundle/nifi-soap-processors/src/test/java/org/apache/nifi/processors/soap/VerifyRequestCallback.java
@@ -1,0 +1,51 @@
+package org.apache.nifi.processors.soap;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.mockserver.mock.action.ExpectationCallback;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * This callback is used to verify that the request sent to the soap server is valid XML.
+ * Created by frankm on 2/28/17.
+ */
+public class VerifyRequestCallback implements ExpectationCallback {
+
+    private static final Logger logger = LoggerFactory.getLogger(VerifyRequestCallback.class);
+
+    private final String xmlBody =
+            "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n" +
+            "<SOAP-ENV:Envelope SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\">\n" +
+            "    <SOAP-ENV:Body>\n" +
+            "        <ns1:LatLonListZipCodeResponse xmlns:ns1=\"http://graphical.weather.gov/xml/DWMLgen/wsdl/ndfdXML.wsdl\">\n" +
+            "            <listLatLonOut xsi:type=\"xsd:string\"></listLatLonOut>\n" +
+            "        </ns1:LatLonListZipCodeResponse>\n" +
+            "    </SOAP-ENV:Body>\n" +
+            "</SOAP-ENV:Envelope>";
+
+    public VerifyRequestCallback() {
+    }
+
+    @Override
+    public HttpResponse handle(HttpRequest httpRequest) {
+        String soapRequest = httpRequest.getBodyAsString();
+        logger.info("PATH: {}", httpRequest.getPath().getValue());
+        XmlMapper mapper = new XmlMapper();
+        try {
+            mapper.readValue(soapRequest, new TypeReference<Map<String, Object>>() {
+            });
+        }
+        catch (IOException e) {
+            logger.error("REQUEST: " + soapRequest);
+            logger.error(e.getMessage(), e);
+            return HttpResponse.notFoundResponse();
+        }
+        return HttpResponse.response(xmlBody);
+    }
+}


### PR DESCRIPTION
Changes:
* Input to the processor is required. I did this because many services allow a date to be passed in which represents the last time you queried the service in order to receive incremental data. This way, an UpdateAttributes processor can be used in front of this. If this isn't needed, a simple GenerateFlowFile processor can be used.
* Dynamic properties allow for expression language. Along the same lines as the reasoning for above with dates and the like.
* Added the ability to do authorization with SOAP headers in addition to http basic authentication. The property provided for this is a string containing the json structure on how the headers should be sent. Variables can be used to substitute username and password.
* I added a parameter to specify the namespace for the XML document being sent. Sometimes, this is different from the WSDL and from the endpoint URL so I wanted to allow this flexibility.
* Some services require the SOAPAction header to be set, so I'm setting that in all cases. More testing may be needed on this.
* I added a parameter to specify whether the returned data should be the entire document or the data after the first element. Different services do different things, so again, I'm trying to make this more flexible.